### PR TITLE
Add database dependencies to version catalog

### DIFF
--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -2,3 +2,25 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.plugin.serialization)
 }
+
+dependencies {
+    // Common module
+    implementation(project(":common"))
+
+    // Kotlin serialization
+    implementation(libs.ktor.serialization.kotlinx.json)
+
+    // Database dependencies
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.dao)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.postgresql)
+    implementation(libs.hikari)
+
+    // Flyway migrations
+    implementation(libs.flyway.core)
+    implementation(libs.flyway.database.postgresql)
+
+    // Testing
+    testImplementation(libs.kotlin.test.junit)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,10 @@ ktor = "3.3.3"
 logback = "1.4.14"
 dotenv = "6.1.4"
 jbcrypt = "0.4"
+exposed = "0.57.0"
+postgresql = "42.7.4"
+hikari = "6.2.1"
+flyway = "11.1.0"
 
 [libraries]
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
@@ -27,6 +31,13 @@ ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref 
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 dotenv-kotlin = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv"}
 jbcrypt = { module = "org.mindrot:jbcrypt", version.ref = "jbcrypt"}
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
This commit adds all necessary database-related dependencies to support PostgreSQL, Exposed ORM, HikariCP connection pooling, and Flyway migrations.

Changes:
- Added versions for exposed (0.57.0), postgresql (42.7.4), hikari (6.2.1), and flyway (11.1.0) to gradle/libs.versions.toml
- Added library declarations for exposed-core, exposed-dao, exposed-jdbc, postgresql, hikari, flyway-core, and flyway-database-postgresql
- Updated database/build.gradle.kts with all database dependencies

This resolves Issue #50 and unblocks database configuration and Flyway migration setup.

Fixes #50