### PR TITLE
Configure database connection and HikariCP pool

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -8,3 +8,12 @@ jwt:
   domain: "https://jwt-provider-domain/"
   audience: "jwt-audience"
   realm: "ktor sample app"
+database:
+  host: ${DB_HOST:localhost}
+  port: ${DB_PORT:5432}
+  name: ${DB_NAME:eros}
+  user: ${DB_USER:postgres}
+  password: ${DB_PASSWORD:postgres}
+  poolSize: ${DB_POOL_SIZE:10}
+  maxLifetime: ${DB_MAX_LIFETIME:600000}
+  connectionTimeout: ${DB_CONNECTION_TIMEOUT:30000}

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -7,8 +7,9 @@ dependencies {
     // Common module
     implementation(project(":common"))
 
-    // Kotlin serialization
+    // Ktor dependencies
     implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.server.config.yaml)
 
     // Database dependencies
     implementation(libs.exposed.core)
@@ -23,4 +24,5 @@ dependencies {
 
     // Testing
     testImplementation(libs.kotlin.test.junit)
+    testImplementation(libs.ktor.server.test.host)
 }

--- a/database/src/main/kotlin/com/eros/database/DatabaseConfig.kt
+++ b/database/src/main/kotlin/com/eros/database/DatabaseConfig.kt
@@ -1,0 +1,89 @@
+package com.eros.database
+
+import io.ktor.server.config.*
+
+/**
+ * Configuration data class for database connection settings.
+ *
+ * **What**: Holds all necessary parameters for establishing and managing database connections
+ * via HikariCP connection pool.
+ *
+ * **How**: Loads configuration from Ktor's ApplicationConfig (application.yaml) with support
+ * for environment variable substitution. Generates JDBC URLs dynamically based on host, port, and database name.
+ *
+ * **Why**: Centralizes database configuration in a type-safe, immutable data class. This approach
+ * enables environment-specific configuration through environment variables while providing
+ * sensible defaults for local development.
+ *
+ * @property host Database server hostname (e.g., "localhost", "db.example.com")
+ * @property port Database server port (default PostgreSQL: 5432)
+ * @property name Database name/schema to connect to
+ * @property user Database username for authentication
+ * @property password Database password for authentication
+ * @property poolSize Maximum number of connections in the HikariCP pool
+ * @property maxLifetime Maximum lifetime of a connection in milliseconds (10 minutes recommended)
+ * @property connectionTimeout Maximum time to wait for a connection in milliseconds (30 seconds recommended)
+ */
+data class DatabaseConfig(
+    val host: String,
+    val port: Int,
+    val name: String,
+    val user: String,
+    val password: String,
+    val poolSize: Int,
+    val maxLifetime: Long,
+    val connectionTimeout: Long
+) {
+    /**
+     * Computed JDBC URL for PostgreSQL connection.
+     *
+     * **What**: Generates the JDBC connection string in PostgreSQL format.
+     *
+     * **How**: Combines host, port, and database name into standard PostgreSQL JDBC URL format.
+     *
+     * **Why**: Eliminates manual URL construction and ensures consistent format across the application.
+     *
+     * @return JDBC URL in format: `jdbc:postgresql://host:port/name`
+     */
+    val jdbcUrl: String
+        get() = "jdbc:postgresql://$host:$port/$name"
+
+    companion object {
+        /**
+         * Factory method to create DatabaseConfig from Ktor's ApplicationConfig.
+         *
+         * **What**: Extracts database configuration from application.yaml and constructs a DatabaseConfig instance.
+         *
+         * **How**: Reads properties from the "database.*" namespace in ApplicationConfig, converting
+         * string values to appropriate types (Int, Long). Supports environment variable substitution
+         * via Ktor's `${VAR:default}` syntax.
+         *
+         * **Why**: Provides a single source of truth for configuration loading. By using Ktor's
+         * ApplicationConfig, we automatically get environment variable support and validation.
+         *
+         * Configuration example in application.yaml:
+         * ```yaml
+         * database:
+         *   host: ${DB_HOST:localhost}
+         *   port: ${DB_PORT:5432}
+         *   name: ${DB_NAME:eros}
+         * ```
+         *
+         * @param config Ktor ApplicationConfig instance (typically from Application.environment.config)
+         * @return DatabaseConfig instance populated from configuration
+         * @throws ApplicationConfigurationException if required properties are missing
+         */
+        fun fromApplicationConfig(config: ApplicationConfig): DatabaseConfig {
+            return DatabaseConfig(
+                host = config.property("database.host").getString(),
+                port = config.property("database.port").getString().toInt(),
+                name = config.property("database.name").getString(),
+                user = config.property("database.user").getString(),
+                password = config.property("database.password").getString(),
+                poolSize = config.property("database.poolSize").getString().toInt(),
+                maxLifetime = config.property("database.maxLifetime").getString().toLong(),
+                connectionTimeout = config.property("database.connectionTimeout").getString().toLong()
+            )
+        }
+    }
+}

--- a/database/src/main/kotlin/com/eros/database/DatabaseFactory.kt
+++ b/database/src/main/kotlin/com/eros/database/DatabaseFactory.kt
@@ -1,0 +1,67 @@
+package com.eros.database
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import javax.sql.DataSource
+
+/**
+ * Factory object for creating and configuring HikariCP database connection pools.
+ *
+ * **What**: Provides a centralized location for DataSource creation with optimized
+ * HikariCP configuration for PostgreSQL connections.
+ *
+ * **How**: Configures HikariCP with production-ready settings including connection pooling,
+ * transaction isolation, and timeout management. Uses the builder pattern via `apply { }`
+ * to configure HikariConfig before creating the DataSource.
+ *
+ * **Why**: HikariCP is the fastest and most reliable connection pool for JDBC. Centralizing
+ * DataSource creation ensures consistent configuration across the application and simplifies
+ * testing by allowing easy DataSource mocking.
+ */
+object DatabaseFactory {
+    /**
+     * Creates a configured HikariCP DataSource for PostgreSQL connections.
+     *
+     * **What**: Initializes a HikariCP connection pool with PostgreSQL-specific settings
+     * optimized for consistency and performance.
+     *
+     * **How**:
+     * - Configures HikariCP with provided database credentials and connection settings
+     * - Sets `autoCommit = false` to require explicit transaction management (prevents accidental commits)
+     * - Uses `TRANSACTION_REPEATABLE_READ` isolation level for consistent reads within transactions
+     * - Validates configuration before creating the DataSource to fail fast on misconfiguration
+     *
+     * **Why**:
+     * - **Connection Pooling**: Reuses connections instead of creating new ones, improving performance
+     * - **No Auto-Commit**: Ensures all database operations are explicitly wrapped in transactions via Exposed
+     * - **Repeatable Read**: Prevents phantom reads and ensures consistency during multi-step operations
+     * - **Timeout Management**: Prevents hanging connections with configurable timeout
+     * - **Max Lifetime**: Recycles old connections to avoid stale connections and database-side timeouts
+     *
+     * Configuration parameters:
+     * - `jdbcUrl`: PostgreSQL JDBC connection string
+     * - `username/password`: Database credentials
+     * - `maximumPoolSize`: Maximum number of connections in pool (default: 10)
+     * - `maxLifetime`: Maximum connection lifetime in ms (default: 600000 = 10 minutes)
+     * - `connectionTimeout`: Maximum time to wait for connection in ms (default: 30000 = 30 seconds)
+     *
+     * @param config DatabaseConfig containing connection parameters
+     * @return Configured HikariDataSource ready for use with Exposed ORM
+     * @throws IllegalArgumentException if HikariConfig validation fails
+     */
+    fun createDataSource(config: DatabaseConfig): DataSource {
+        val hikariConfig = HikariConfig().apply {
+            jdbcUrl = config.jdbcUrl
+            username = config.user
+            password = config.password
+            driverClassName = "org.postgresql.Driver"
+            maximumPoolSize = config.poolSize
+            maxLifetime = config.maxLifetime
+            connectionTimeout = config.connectionTimeout
+            isAutoCommit = false
+            transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            validate()
+        }
+        return HikariDataSource(hikariConfig)
+    }
+}

--- a/database/src/test/kotlin/com/eros/database/DatabaseConfigTest.kt
+++ b/database/src/test/kotlin/com/eros/database/DatabaseConfigTest.kt
@@ -1,0 +1,130 @@
+package com.eros.database
+
+import io.ktor.server.config.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for DatabaseConfig configuration loading and validation.
+ *
+ * **What**: Verifies that DatabaseConfig correctly loads configuration from ApplicationConfig
+ * and generates proper JDBC URLs.
+ *
+ * **How**: Uses MapApplicationConfig to simulate application.yaml configuration and validates
+ * that all properties are correctly extracted and type-converted.
+ *
+ * **Why**: Ensures configuration loading is robust and catches issues before deployment.
+ * Tests both default local development settings and custom production-like configurations.
+ */
+class DatabaseConfigTest {
+
+    /**
+     * Tests DatabaseConfig loading with default local development values.
+     *
+     * **What**: Verifies configuration loading with typical localhost development settings.
+     *
+     * **How**: Creates a MapApplicationConfig with default values (localhost:5432, postgres user)
+     * and validates that fromApplicationConfig correctly extracts all properties.
+     *
+     * **Why**: Default configuration is the most common use case during development.
+     * This test ensures developers can start the application without custom environment variables.
+     */
+    @Test
+    fun testDatabaseConfigFromApplicationConfigWithDefaults() {
+        // Create a test configuration with default values
+        val configMap = mapOf(
+            "database.host" to "localhost",
+            "database.port" to "5432",
+            "database.name" to "eros",
+            "database.user" to "postgres",
+            "database.password" to "postgres",
+            "database.poolSize" to "10",
+            "database.maxLifetime" to "600000",
+            "database.connectionTimeout" to "30000"
+        )
+
+        val applicationConfig = MapApplicationConfig(
+            configMap.map { it.key to it.value }
+        )
+
+        val databaseConfig = DatabaseConfig.fromApplicationConfig(applicationConfig)
+
+        assertEquals("localhost", databaseConfig.host)
+        assertEquals(5432, databaseConfig.port)
+        assertEquals("eros", databaseConfig.name)
+        assertEquals("postgres", databaseConfig.user)
+        assertEquals("postgres", databaseConfig.password)
+        assertEquals(10, databaseConfig.poolSize)
+        assertEquals(600000L, databaseConfig.maxLifetime)
+        assertEquals(30000L, databaseConfig.connectionTimeout)
+    }
+
+    /**
+     * Tests JDBC URL generation from DatabaseConfig properties.
+     *
+     * **What**: Verifies that the jdbcUrl computed property generates correct PostgreSQL JDBC URLs.
+     *
+     * **How**: Creates a DatabaseConfig with custom values and checks that the jdbcUrl property
+     * returns the expected format: `jdbc:postgresql://host:port/name`
+     *
+     * **Why**: JDBC URL format must be exact for PostgreSQL driver to accept the connection.
+     * This test prevents URL format regressions.
+     */
+    @Test
+    fun testDatabaseConfigJdbcUrl() {
+        val config = DatabaseConfig(
+            host = "testhost",
+            port = 5433,
+            name = "testdb",
+            user = "testuser",
+            password = "testpass",
+            poolSize = 5,
+            maxLifetime = 500000L,
+            connectionTimeout = 20000L
+        )
+
+        assertEquals("jdbc:postgresql://testhost:5433/testdb", config.jdbcUrl)
+    }
+
+    /**
+     * Tests DatabaseConfig loading with custom production-like values.
+     *
+     * **What**: Verifies configuration loading with non-default values simulating a production environment.
+     *
+     * **How**: Creates a MapApplicationConfig with custom host, port, larger pool size, and longer timeouts.
+     * Validates that all custom values are correctly extracted and the JDBC URL is properly generated.
+     *
+     * **Why**: Production environments use different settings than development (remote host, larger pools,
+     * longer timeouts). This test ensures environment variable overrides work correctly for production deployment.
+     */
+    @Test
+    fun testDatabaseConfigFromApplicationConfigWithCustomValues() {
+        // Create a test configuration with custom values
+        val configMap = mapOf(
+            "database.host" to "db.example.com",
+            "database.port" to "5433",
+            "database.name" to "production_db",
+            "database.user" to "admin",
+            "database.password" to "secretpass",
+            "database.poolSize" to "20",
+            "database.maxLifetime" to "900000",
+            "database.connectionTimeout" to "60000"
+        )
+
+        val applicationConfig = MapApplicationConfig(
+            configMap.map { it.key to it.value }
+        )
+
+        val databaseConfig = DatabaseConfig.fromApplicationConfig(applicationConfig)
+
+        assertEquals("db.example.com", databaseConfig.host)
+        assertEquals(5433, databaseConfig.port)
+        assertEquals("production_db", databaseConfig.name)
+        assertEquals("admin", databaseConfig.user)
+        assertEquals("secretpass", databaseConfig.password)
+        assertEquals(20, databaseConfig.poolSize)
+        assertEquals(900000L, databaseConfig.maxLifetime)
+        assertEquals(60000L, databaseConfig.connectionTimeout)
+        assertEquals("jdbc:postgresql://db.example.com:5433/production_db", databaseConfig.jdbcUrl)
+    }
+}


### PR DESCRIPTION
This commit establishes the database connectivity layer using HikariCP connection pooling, which will be used by Exposed ORM and Flyway migrations.

Changes:
- Added database configuration section to application.yaml with environment variable support
- Created DatabaseConfig data class with fromApplicationConfig factory method
- Created DatabaseFactory object with createDataSource method for HikariCP setup
- Added ktor-server-config-yaml dependency to database module
- Added comprehensive unit tests for DatabaseConfig

Configuration features:
- Environment variables with sensible defaults for local development
- HikariCP pool configured with proper settings (pool size, timeouts, transaction isolation)
- JDBC URL format for PostgreSQL
- TRANSACTION_REPEATABLE_READ for consistency
- Connection timeout of 30s prevents hanging connections
- Max lifetime of 10 minutes helps with connection staleness
- autoCommit disabled for explicit transaction management

Tests verify:
- Configuration loading with default values
- Configuration loading with custom values
- JDBC URL generation

This resolves Issue #51 and unblocks database plugin setup.

Fixes #51