### PR TITLE
Set up Flyway migration infrastructure

### DIFF
--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -9,4 +9,5 @@
     </root>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
+    <logger name="org.flywaydb" level="INFO"/>
 </configuration>

--- a/database/src/main/kotlin/com/eros/database/FlywayConfig.kt
+++ b/database/src/main/kotlin/com/eros/database/FlywayConfig.kt
@@ -1,0 +1,78 @@
+package com.eros.database
+
+import org.flywaydb.core.Flyway
+import javax.sql.DataSource
+
+/**
+ * Configuration object for Flyway database migrations.
+ *
+ * Provides methods to manage database schema versioning through SQL migration scripts.
+ * Flyway tracks applied migrations in the `flyway_schema_history` table.
+ *
+ * Migration files follow the naming convention: `V{version}__{description}.sql`
+ * Example: `V1__auth_tables.sql`, `V2__user_profiles.sql`
+ */
+object FlywayConfig {
+
+    private const val MIGRATION_LOCATION = "classpath:db/migration"
+    private const val BASELINE_VERSION = "0"
+
+    /**
+     * Runs all pending database migrations.
+     *
+     * Applies migrations in version order from the `db/migration` directory.
+     * If the database is not versioned, creates a baseline at version 0 before applying migrations.
+     *
+     * @param dataSource HikariCP DataSource for database connection
+     * @throws org.flywaydb.core.api.FlywayException if migration fails
+     */
+    fun migrate(dataSource: DataSource) {
+        val flyway = Flyway.configure()
+            .dataSource(dataSource)
+            .locations(MIGRATION_LOCATION)
+            .baselineOnMigrate(true)
+            .baselineVersion(BASELINE_VERSION)
+            .load()
+
+        flyway.migrate()
+    }
+
+    /**
+     * Drops all database objects (tables, views, procedures) managed by Flyway.
+     *
+     * **WARNING**: This is destructive and should only be used in development/testing.
+     * Production environments should have `cleanDisabled = true` in Flyway configuration.
+     *
+     * @param dataSource HikariCP DataSource for database connection
+     */
+    fun clean(dataSource: DataSource) {
+        val flyway = Flyway.configure()
+            .dataSource(dataSource)
+            .locations(MIGRATION_LOCATION)
+            .cleanDisabled(false)
+            .load()
+
+        flyway.clean()
+    }
+
+    /**
+     * Returns migration status information as a formatted string.
+     *
+     * Shows all migrations (pending, applied, failed) with their version, description, and state.
+     * Useful for debugging migration issues or verifying database version.
+     *
+     * @param dataSource HikariCP DataSource for database connection
+     * @return Formatted string with migration status (one migration per line)
+     */
+    fun info(dataSource: DataSource): String {
+        val flyway = Flyway.configure()
+            .dataSource(dataSource)
+            .locations(MIGRATION_LOCATION)
+            .load()
+
+        val info = flyway.info()
+        return info.all().joinToString("\n") { migration ->
+            "${migration.version} - ${migration.description} [${migration.state}]"
+        }
+    }
+}

--- a/database/src/main/resources/db/migration/V0__init.sql
+++ b/database/src/main/resources/db/migration/V0__init.sql
@@ -1,0 +1,12 @@
+-- Initial migration placeholder
+-- This establishes the baseline for Flyway versioning
+-- Actual table creation will be done in subsequent migrations (V1, V2, etc.)
+
+-- Create PostgreSQL extensions if needed
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Set timezone to UTC for consistent timestamp behavior
+SET timezone = 'UTC';
+
+-- Baseline migration completed successfully
+-- Next migration: V1__auth_tables.sql (authentication tables)


### PR DESCRIPTION
This commit establishes the Flyway database migration framework, enabling versioned schema changes through SQL migration scripts.

Changes:
- Created migration directory structure at database/src/main/resources/db/migration/
- Created FlywayConfig object with migrate(), clean(), and info() methods
- Created V0__init.sql baseline migration that enables uuid-ossp extension and sets UTC timezone
- Added Flyway logging configuration to logback.xml

FlywayConfig features:
- migrate(): Applies all pending migrations with baselineOnMigrate enabled
- clean(): Drops all database objects (development/testing only)
- info(): Returns formatted migration status for debugging

Migration conventions:
- Files follow V{version}__{description}.sql naming (e.g., V1__auth_tables.sql)
- V0 establishes baseline, subsequent migrations add tables/schemas
- Flyway tracks applied migrations in flyway_schema_history table

This resolves Issue #52 and unblocks auth table creation (Issue #1).

Fixes #52 