### PR TITLE
Fix JAR path in release workflows

### DIFF
--- a/.github/workflows/build-and-release-develop.yml
+++ b/.github/workflows/build-and-release-develop.yml
@@ -52,7 +52,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Rename JAR for release
-        run: cp ./app/build/libs/eros-backend-all.jar ./eros-backend-develop-${{ steps.version.outputs.version }}.jar
+        run: cp ./app/build/libs/app-all.jar ./eros-backend-develop-${{ steps.version.outputs.version }}.jar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-and-release-main.yml
+++ b/.github/workflows/build-and-release-main.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Rename JAR for release
-        run: cp ./app/build/libs/eros-backend-all.jar ./eros-backend-${{ steps.version.outputs.version }}.jar
+        run: cp ./app/build/libs/app-all.jar ./eros-backend-${{ steps.version.outputs.version }}.jar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Corrected the Fat JAR filename from eros-backend-all.jar to app-all.jar to match the actual output from the buildFatJar Gradle task.

This fixes the "No such file or directory" error during release creation.