### PR TITLE
The workflow will fail because the JAR filename doesn't match the ktor plugin's default output.

### DIFF
--- a/.github/workflows/build-and-release-develop.yml
+++ b/.github/workflows/build-and-release-develop.yml
@@ -52,7 +52,14 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Rename JAR for release
-        run: cp ./app/build/libs/app-all.jar ./eros-backend-develop-${{ steps.version.outputs.version }}.jar
+        run: |
+          FAT_JAR=$(find ./app/build/libs -name "app-*-all.jar" -type f | head -n 1)
+          if [ -z "$FAT_JAR" ]; then
+            echo "Error: No Fat JAR matching pattern 'app-*-all.jar' found in ./app/build/libs"
+            exit 1
+          fi
+          echo "Found Fat JAR: $FAT_JAR"
+          cp "$FAT_JAR" ./eros-backend-develop-${{ steps.version.outputs.version }}.jar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-and-release-main.yml
+++ b/.github/workflows/build-and-release-main.yml
@@ -53,7 +53,14 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Rename JAR for release
-        run: cp ./app/build/libs/app-all.jar ./eros-backend-${{ steps.version.outputs.version }}.jar
+        run: |
+          FAT_JAR=$(find ./app/build/libs -name "app-*-all.jar" -type f | head -n 1)
+          if [ -z "$FAT_JAR" ]; then
+            echo "Error: No Fat JAR matching pattern 'app-*-all.jar' found in ./app/build/libs"
+            exit 1
+          fi
+          echo "Found Fat JAR: $FAT_JAR"
+          cp "$FAT_JAR" ./eros-backend-${{ steps.version.outputs.version }}.jar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The buildFatJar task from the ktor Gradle plugin produces build/libs/app-0.0.1-all.jar by default (with version), but line 56 attempts to copy app-all.jar (without version). The copy will fail and the release asset will be missing.

Use the hardened approach to locate the produced JAR dynamically: