### PR TITLE
Adding Long and Lat to City.

### DIFF
--- a/database/src/main/resources/db/migration/V2__cities_table.sql
+++ b/database/src/main/resources/db/migration/V2__cities_table.sql
@@ -3,9 +3,15 @@ CREATE TABLE IF NOT EXISTS cities (
     city_id BIGSERIAL PRIMARY KEY,
     name VARCHAR(128) NOT NULL UNIQUE,
 
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+
     -- Timestamps
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_city_latitude_range CHECK (coordinates_latitude BETWEEN -90 AND 90),
+    CONSTRAINT chk_city_longitude_range CHECK (coordinates_longitude BETWEEN -180 AND 180)
 );
 
 -- Indexes for master tables (name lookups)
@@ -14,3 +20,5 @@ CREATE INDEX idx_cities_name ON cities(name);
 -- Comments for columns or table
 COMMENT ON TABLE cities IS 'List of all cities available for dating preferences';
 COMMENT ON COLUMN cities.name IS 'Name of a city containing an activity';
+COMMENT ON COLUMN cities.longitude IS 'Longitude of the city centre';
+COMMENT ON COLUMN cities.latitude IS 'Latitude of the city centre';

--- a/users/src/main/kotlin/com/eros/users/models/City.kt
+++ b/users/src/main/kotlin/com/eros/users/models/City.kt
@@ -6,36 +6,54 @@ import java.time.Instant
 /**
  * Domain object for a city.
  *
- * @param cityId - id of the city.
- * @param cityName - Name of the city.
- * @param createdAt - Time of creation.
- * @param updatedAt - Time of late update.
+ * @param cityId id of the city.
+ * @param cityName Name of the city.
+ * @param longitude Longitude of the city centre.
+ * @param latitude Latitude of the city centre.
+ * @param createdAt Time of creation.
+ * @param updatedAt Time of late update.
  */
 data class City(
     // City id.
-    val cityId : Long,
+    val cityId: Long,
 
     // City name.
-    val cityName : String,
+    val cityName: String,
+
+    // City location.
+    val longitude: Double,
+    val latitude: Double,
 
     // Timestamps
     val createdAt: Instant,
     val updatedAt: Instant,
 )
 
+
 /**
- * Lightweight city DTO without timestamps.
+ * City DTO without timestamps.
  * Used in API responses and when passing city references between services.
- * Provides only essential information (id and name) for better performance and cleaner APIs.
+ * Provides only essential information (id, name, and longitude and latitude of the city centre) for better performance and cleaner APIs.
  *
  * @param cityId - Unique identifier of the city.
  * @param cityName - Name of the city.
+ * @param longitude Longitude of the city centre.
+ * @param latitude Latitude of the city centre.
  */
 @Serializable
 data class CityDTO(
     val cityId: Long,
-    val cityName: String
-)
+    val cityName: String,
+    val longitude: Double,
+    val latitude: Double
+) {
+    init {
+        require(cityName.isNotBlank()) {"City name must not be empty."}
+        require(latitude in -90.0..90.0) { "Latitude must be between -90 and 90" }
+        require(longitude in -180.0..180.0) { "Longitude must be between -180 and 180" }
+    }
+}
+
 
 /**
  * Extension function to convert a full City entity to a lightweight CityDTO.
@@ -43,29 +61,53 @@ data class CityDTO(
  */
 fun City.toDTO() = CityDTO(
     cityId = this.cityId,
-    cityName = this.cityName
+    cityName = this.cityName,
+    longitude = this.longitude,
+    latitude = this.latitude
 )
+
 
 /**
  * Data class for CreateCityRequest - This is used for adding a city to the Cities db table.
  *
  * @param cityName - Name of the city to be added.
+ * @param longitude Longitude of the city centre.
+ * @param latitude Latitude of the city centre.
  *
  */
 @Serializable
 data class CreateCityRequest(
-    val cityName : String
-)
+    val cityName: String,
+    val longitude: Double,
+    val latitude: Double
+) {
+    init {
+        require(cityName.isNotBlank()) {"City name must not be empty."}
+        require(latitude in -90.0..90.0) { "Latitude must be between -90 and 90" }
+        require(longitude in -180.0..180.0) { "Longitude must be between -180 and 180" }
+    }
+}
+
 
 /**
  * Data class for UpdateCityRequest - This is used for updating the name of a city in the Cities db table.
  *
- * @param cityId - The id of the city to be updated.
- * @param newCityName - New name of the city of [cityId]
+ * @param cityId The id of the city to be updated.
+ * @param newCityName New name of the city of [cityId]
+ * @param newCityLongitude Longitude of the city centre.
+ * @param newCityLatitude Latitude of the city centre.
  *
  */
 @Serializable
 data class UpdateCityRequest(
-    val cityId : Long,
-    val newCityName : String
-)
+    val cityId: Long,
+    val newCityName: String? = null,
+    val newCityLongitude: Double? = null,
+    val newCityLatitude: Double? = null,
+) {
+    init {
+        newCityName?.let { require(it.isNotBlank()) {"City name must not be empty." } }
+        newCityLatitude?.let { require(it in -90.0..90.0) { "Latitude must be between -90 and 90" } }
+        newCityLongitude?.let { require(it in -180.0..180.0) { "Longitude must be between -180 and 180" } }
+    }
+}

--- a/users/src/main/kotlin/com/eros/users/models/City.kt
+++ b/users/src/main/kotlin/com/eros/users/models/City.kt
@@ -27,7 +27,13 @@ data class City(
     // Timestamps
     val createdAt: Instant,
     val updatedAt: Instant,
-)
+){
+    init {
+        require(cityName.isNotBlank()) {"City name must not be empty." }
+        require(latitude in -90.0..90.0) { "Latitude must be between -90 and 90" }
+        require(longitude in -180.0..180.0) { "Longitude must be between -180 and 180" }
+    }
+}
 
 
 /**
@@ -46,13 +52,7 @@ data class CityDTO(
     val cityName: String,
     val longitude: Double,
     val latitude: Double
-) {
-    init {
-        require(cityName.isNotBlank()) {"City name must not be empty."}
-        require(latitude in -90.0..90.0) { "Latitude must be between -90 and 90" }
-        require(longitude in -180.0..180.0) { "Longitude must be between -180 and 180" }
-    }
-}
+)
 
 
 /**
@@ -80,13 +80,7 @@ data class CreateCityRequest(
     val cityName: String,
     val longitude: Double,
     val latitude: Double
-) {
-    init {
-        require(cityName.isNotBlank()) {"City name must not be empty."}
-        require(latitude in -90.0..90.0) { "Latitude must be between -90 and 90" }
-        require(longitude in -180.0..180.0) { "Longitude must be between -180 and 180" }
-    }
-}
+)
 
 
 /**
@@ -104,10 +98,4 @@ data class UpdateCityRequest(
     val newCityName: String? = null,
     val newCityLongitude: Double? = null,
     val newCityLatitude: Double? = null,
-) {
-    init {
-        newCityName?.let { require(it.isNotBlank()) {"City name must not be empty." } }
-        newCityLatitude?.let { require(it in -90.0..90.0) { "Latitude must be between -90 and 90" } }
-        newCityLongitude?.let { require(it in -180.0..180.0) { "Longitude must be between -180 and 180" } }
-    }
-}
+)

--- a/users/src/main/kotlin/com/eros/users/repository/CityRepositoryImpl.kt
+++ b/users/src/main/kotlin/com/eros/users/repository/CityRepositoryImpl.kt
@@ -26,6 +26,8 @@ class CityRepositoryImpl(
         statement.apply {
             this[Cities.cityName] = entity.cityName
             this[Cities.createdAt] = entity.createdAt
+            this[Cities.longitude] = entity.longitude
+            this[Cities.latitude] = entity.latitude
             this[Cities.updatedAt] = Instant.now(clock)
         }
     }
@@ -39,6 +41,8 @@ class CityRepositoryImpl(
         val now = Instant.now(clock)
         return Cities.insertReturning {
             it[cityName] = entity.cityName
+            it[longitude] = entity.longitude
+            it[latitude] = entity.latitude
             it[createdAt] = now
             it[updatedAt] = now
         }.single().toDomain()

--- a/users/src/main/kotlin/com/eros/users/repository/PreferenceRepositoryImpl.kt
+++ b/users/src/main/kotlin/com/eros/users/repository/PreferenceRepositoryImpl.kt
@@ -149,6 +149,8 @@ class PreferenceRepositoryImpl(
                 City(
                     cityId = row[Cities.cityId],
                     cityName = row[Cities.cityName],
+                    longitude = row[Cities.longitude],
+                    latitude = row[Cities.latitude],
                     createdAt = row[Cities.createdAt],
                     updatedAt = row[Cities.updatedAt]
                 )

--- a/users/src/main/kotlin/com/eros/users/routes/CityRoutes.kt
+++ b/users/src/main/kotlin/com/eros/users/routes/CityRoutes.kt
@@ -20,39 +20,47 @@ import io.ktor.server.routing.route
 
 
 fun Route.cityRoutes(cityService: CityService) {
+    // User routes
     route("/city") {
-        requireRoles("ADMIN", "EMPLOYEE")
-
-        post {
-            val request = call.receive<CreateCityRequest>()
-
-            if (cityService.doesExists(request.cityName))
-                throw ConflictException("City already exists")
-
-            val city = cityService.createCity(request)
-            call.respond(HttpStatusCode.OK, city)
+        requireRoles("USER", "ADMIN", "EMPLOYEE")
+        get("/all"){
+            val cities = cityService.getAllCities().map { it.toDTO() }
+            call.respond(HttpStatusCode.OK, cities)
         }
 
         get("/{id}") {
             val id = call.parameters["id"]?.toLong()
                 ?: throw BadRequestException("Invalid city ID provided.")
 
-            val city = cityService.findByCityId(id) ?: throw NotFoundException("City not found.")
-            call.respond(HttpStatusCode.OK, city)
+            val city = cityService.findByCityId(id)
+                ?: throw NotFoundException("City not found.")
+            call.respond(HttpStatusCode.OK, city.toDTO())
         }
+    }
 
+    route("/city/admin") {
+        // Protected endpoints - only ADMIN, EMPLOYEE
+        requireRoles("ADMIN", "EMPLOYEE")
         patch("/{id}") {
             val id = call.parameters["id"]?.toLong()
                 ?: throw BadRequestException("Invalid city ID provided.")
 
             val request = call.receive<UpdateCityRequest>()
+            val updated = cityService.updateCity(id, request)
+                ?: throw NotFoundException("City not found")
 
-            val updated = cityService.updateCity(id, request) ?: throw NotFoundException("City not found")
+            call.respond(HttpStatusCode.OK, updated.toDTO())
+        }
+        post {
+            val request = call.receive<CreateCityRequest>()
+            if (cityService.doesExists(request.cityName))
+                throw ConflictException("City already exists")
 
-            call.respond(HttpStatusCode.OK, updated)
+            val city = cityService.createCity(request)
+            call.respond(HttpStatusCode.Created, city.toDTO())
         }
 
-        delete("/{id}") {
+        delete("/{id}"){
             val id = call.parameters["id"]?.toLong()
                 ?: throw BadRequestException("Invalid city ID provided.")
 
@@ -63,14 +71,6 @@ fun Route.cityRoutes(cityService: CityService) {
                 call.respond(HttpStatusCode.NotFound, "City not found")
             }
         }
-
-        /**
-         * Return a list of all the cities : id and name.
-         */
-        get("/all") {
-            val cities = cityService.getAllCities().map{ it.toDTO()}
-            call.respond(HttpStatusCode.OK, cities)
-        }
-
     }
+
 }

--- a/users/src/main/kotlin/com/eros/users/routes/CityRoutes.kt
+++ b/users/src/main/kotlin/com/eros/users/routes/CityRoutes.kt
@@ -1,5 +1,6 @@
 package com.eros.users.routes
 
+import com.eros.auth.extensions.requireFirebasePrincipal
 import com.eros.auth.extensions.requireRoles
 import com.eros.common.errors.BadRequestException
 import com.eros.common.errors.ConflictException
@@ -35,6 +36,17 @@ fun Route.cityRoutes(cityService: CityService) {
             val city = cityService.findByCityId(id)
                 ?: throw NotFoundException("City not found.")
             call.respond(HttpStatusCode.OK, city.toDTO())
+        }
+
+        /**
+         * Path to retrieve the nearest SINGLE/MULTIPLE nearest city/s.
+         */
+        get("/nearest"){
+            throw NotImplementedError("/city/nearest has not been implemented")
+            /*
+            Provide NearestCityRequest (lat, long)
+            Return Single or list of nearest cities
+             */
         }
     }
 

--- a/users/src/main/kotlin/com/eros/users/routes/QARoutes.kt
+++ b/users/src/main/kotlin/com/eros/users/routes/QARoutes.kt
@@ -8,7 +8,6 @@ import com.eros.common.errors.NotFoundException
 import com.eros.common.errors.UnauthorizedException
 import com.eros.users.ProfileAccessControl
 import com.eros.users.models.AddUserQARequest
-import com.eros.users.models.DeleteUserQARequest
 import com.eros.users.models.UpdateUserQARequest
 import com.eros.users.models.UserQACollectionDTO
 import com.eros.users.models.toDTO

--- a/users/src/main/kotlin/com/eros/users/service/CityService.kt
+++ b/users/src/main/kotlin/com/eros/users/service/CityService.kt
@@ -29,6 +29,8 @@ class CityService(
         val city = City(
             cityId = 0L, // DB auto-generates the id on insert
             cityName = request.cityName,
+            longitude = request.longitude,
+            latitude = request.latitude,
             createdAt = now,
             updatedAt = now
         )
@@ -45,7 +47,9 @@ class CityService(
      */
     suspend fun updateCity(cityId: Long, request: UpdateCityRequest): City? = dbQuery {
         val existing = cityRepository.findById(cityId) ?: throw NotFoundException("No city with the provided id: $cityId")
-        val updated = existing.copy(cityName = request.newCityName)
+        val updated = existing.copy(cityName = request.newCityName ?: existing.cityName,
+            longitude = request.newCityLongitude ?: existing.longitude,
+            latitude = request.newCityLatitude ?: existing.latitude)
         cityRepository.update(cityId, updated)
     }
 

--- a/users/src/main/kotlin/com/eros/users/service/CityService.kt
+++ b/users/src/main/kotlin/com/eros/users/service/CityService.kt
@@ -28,7 +28,7 @@ class CityService(
         val now = Instant.now(clock)
         val city = City(
             cityId = 0L, // DB auto-generates the id on insert
-            cityName = request.cityName,
+            cityName = request.cityName.trim(),
             longitude = request.longitude,
             latitude = request.latitude,
             createdAt = now,

--- a/users/src/main/kotlin/com/eros/users/service/PreferenceService.kt
+++ b/users/src/main/kotlin/com/eros/users/service/PreferenceService.kt
@@ -32,7 +32,7 @@ class PreferenceService(
             // Stub City objects carrying just the IDs the repo needs for its batch insert.
             // The full City data is populated by the repo via getUserPreferenceWithCities.
             dateCities = request.dateCities.map { city ->
-                City(cityId = city.cityId, cityName = city.cityName,now,now)
+                City(cityId = city.cityId, cityName = "", longitude = 0.0, latitude = 0.0,now,now)
             },
             reachLevel = request.reachLevel,
             createdAt = now,
@@ -57,7 +57,7 @@ class PreferenceService(
             // Stub City objects carrying just the IDs the repo needs for its batch insert.
             // The full City data is populated by the repo via getUserPreferenceWithCities.
             dateCities = request.dateCities.map { city ->
-                City(cityId = city.cityId, cityName = city.cityName,now,now)
+                City(cityId = city.cityId, cityName = "", longitude = 0.0, latitude = 0.0,now,now)
             },
             reachLevel = request.reachLevel,
             createdAt = now,

--- a/users/src/main/kotlin/com/eros/users/table/Cities.kt
+++ b/users/src/main/kotlin/com/eros/users/table/Cities.kt
@@ -26,6 +26,9 @@ object Cities : Table("cities") {
     // Foreign key to Users table
     val cityName = varchar("city_name", 128).uniqueIndex()
 
+    val longitude = double("longitude")
+    val latitude = double("latitude")
+
     // Timestamps
     val createdAt = timestamp("created_at").clientDefault { Instant.now() }
     val updatedAt = timestamp("updated_at").clientDefault { Instant.now() }
@@ -37,6 +40,8 @@ object Cities : Table("cities") {
 fun ResultRow.toCityDTO() = City(
     cityId = this[Cities.cityId],
     cityName = this[Cities.cityName],
+    longitude = this[Cities.longitude],
+    latitude = this[Cities.latitude],
     createdAt = this[Cities.createdAt],
     updatedAt = this[Cities.updatedAt]
 )

--- a/users/src/test/kotlin/com/eros/users/models/CityTest.kt
+++ b/users/src/test/kotlin/com/eros/users/models/CityTest.kt
@@ -1,0 +1,158 @@
+package com.eros.users.models;
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class CityTest {
+
+    @Nested
+    inner class `LAT LONG`{
+
+        @Test
+        fun `should create city with min latitude`() {
+            val city = CreateCityRequest("Blah", 5.0, -90.0)
+            assertEquals(-90.0, city.latitude)
+        }
+
+        @Test
+        fun `should create city with min latitude 2`() {
+            val city = UpdateCityRequest(0L,"Blah", 5.0, -90.0)
+            assertEquals(-90.0, city.newCityLatitude)
+        }
+
+        @Test
+        fun `should create city with max latitude`() {
+            val city = CreateCityRequest("Blah", 5.0, 90.0)
+            assertEquals(90.0, city.latitude)
+        }
+
+        @Test
+        fun `should create city with max latitude 2`() {
+            val city = UpdateCityRequest(1L,"Blah", 5.0, 90.0)
+            assertEquals(90.0, city.newCityLatitude)
+        }
+
+        @Test
+        fun `should create city with min longitude`() {
+            val city = CreateCityRequest("Blah", -180.0, -5.0)
+            assertEquals(-180.0, city.longitude)
+
+        }
+
+        @Test
+        fun `should create city with min longitude 2`() {
+            val city = UpdateCityRequest(1L, "Blah", -180.0, -5.0)
+            assertEquals(-180.0, city.newCityLongitude)
+
+        }
+
+        @Test
+        fun `should create city with max longitude`() {
+            val city = CreateCityRequest("Blah", 180.0, 50.0)
+            assertEquals(180.0, city.longitude)
+        }
+
+        @Test
+        fun `should create city with max longitude 2`() {
+            val city = UpdateCityRequest(1L, "Blah", 180.0, -5.0)
+            assertEquals(180.0, city.newCityLongitude)
+        }
+
+        @Test
+        fun `should throw exception with invalid latitude`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CreateCityRequest("Blah",5.0,-90.1)
+            }
+            assertEquals("Latitude must be between -90 and 90", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid latitude 2`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CreateCityRequest("Blah",5.0,90.1)
+            }
+            assertEquals("Latitude must be between -90 and 90", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid latitude 3`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                UpdateCityRequest(1L, newCityLatitude = -90.1)
+            }
+            assertEquals("Latitude must be between -90 and 90", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid latitude 4`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                UpdateCityRequest(1L, newCityLatitude = 90.1)
+            }
+            assertEquals("Latitude must be between -90 and 90", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid latitude 5`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CityDTO(1L,"Blah", 5.0, 90.1)
+            }
+            assertEquals("Latitude must be between -90 and 90", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid longitude`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CreateCityRequest("Blah",180.1,5.0)
+            }
+            assertEquals("Longitude must be between -180 and 180", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid longitude 2`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CreateCityRequest("Blah",-180.1,5.0)
+            }
+            assertEquals("Longitude must be between -180 and 180", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with invalid longitude 3`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CityDTO(1L,"Blah",-180.1,5.0)
+            }
+            assertEquals("Longitude must be between -180 and 180", exception.message)
+        }
+
+    }
+
+    @Nested
+    inner class `City name`{
+
+        @Test
+        fun `should throw exception with empty name`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CreateCityRequest("    ",-56.1,5.0)
+            }
+            assertEquals("City name must not be empty.", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with empty name 2`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                UpdateCityRequest(1L,"    ")
+            }
+            assertEquals("City name must not be empty.", exception.message)
+        }
+
+        @Test
+        fun `should throw exception with empty name 3`(){
+            val exception = assertThrows<IllegalArgumentException> {
+                CityDTO(1L,"    ",5.0,5.0)
+            }
+            assertEquals("City name must not be empty.", exception.message)
+        }
+
+    }
+
+}

--- a/users/src/test/kotlin/com/eros/users/repository/CityRepositoryImplTest.kt
+++ b/users/src/test/kotlin/com/eros/users/repository/CityRepositoryImplTest.kt
@@ -74,7 +74,7 @@ class CityRepositoryImplTest {
             val cityName = "London"
 
             val city = dbQuery {
-                repository.create(City(0L, cityName, fixedInstant, fixedInstant))
+                repository.create(City(0L, cityName, 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             assertNotNull(city.cityId)
@@ -87,10 +87,10 @@ class CityRepositoryImplTest {
         @Test
         fun `should auto-increment city IDs`() = runBlocking {
             val city1 = dbQuery {
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris",5.0 ,5.0, fixedInstant, fixedInstant))
             }
             val city2 = dbQuery {
-                repository.create(City(0L, "Berlin", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Berlin", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             assertTrue(city2.cityId > city1.cityId)
@@ -104,7 +104,7 @@ class CityRepositoryImplTest {
             val customRepository = CityRepositoryImpl(customClock)
 
             val city = dbQuery {
-                customRepository.create(City(0L, "Tokyo", customInstant, customInstant))
+                customRepository.create(City(0L, "Tokyo", 5.0 ,5.0,customInstant, customInstant))
             }
 
             assertEquals(customInstant, city.createdAt)
@@ -116,7 +116,7 @@ class CityRepositoryImplTest {
             val cityName = "São Paulo"
 
             val city = dbQuery {
-                repository.create(City(0L, cityName, fixedInstant, fixedInstant))
+                repository.create(City(0L, cityName, 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             assertEquals(cityName, city.cityName)
@@ -126,9 +126,9 @@ class CityRepositoryImplTest {
         fun `should enforce unique city names`() {
             runBlocking {
                 dbQuery {
-                    repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                    repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
                     assertFails {
-                        repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                        repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
                     }
                 }
             }
@@ -142,7 +142,7 @@ class CityRepositoryImplTest {
         fun `should update city name successfully`() = runBlocking {
             val originalName = "TestValue"
             val city = dbQuery {
-                repository.create(City(0L, originalName, fixedInstant, fixedInstant))
+                repository.create(City(0L, originalName, 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             val newName = "AlteredTestValue"
@@ -160,7 +160,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should update updatedAt timestamp on update`() = runBlocking {
             val city = dbQuery {
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             val laterInstant = fixedInstant.plusSeconds(3600)
@@ -181,7 +181,7 @@ class CityRepositoryImplTest {
             val nonExistentId = 999L
 
             val result = dbQuery {
-                repository.update(nonExistentId, City(nonExistentId, "Ghost City", fixedInstant, fixedInstant))
+                repository.update(nonExistentId, City(nonExistentId, "Ghost City", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             assertNull(result)
@@ -191,8 +191,8 @@ class CityRepositoryImplTest {
         fun `should not allow updating to duplicate city name`(){
             runBlocking {
                 dbQuery {
-                    repository.create(City(0L, "London", fixedInstant, fixedInstant))
-                    val paris = repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                    repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
+                    val paris = repository.create(City(0L, "Paris", 5.0 ,5.0,fixedInstant, fixedInstant))
 
                     assertFails {
                         repository.update(paris.cityId, paris.copy(cityName = "London"))
@@ -208,7 +208,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should return true when city name exists`() = runBlocking {
             val exists = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
                 repository.doesExist("London")
             }
 
@@ -225,7 +225,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should be case sensitive`() = runBlocking {
             val existsLowercase = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
                 repository.doesExist("london")
             }
 
@@ -235,7 +235,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should not match partial names`() = runBlocking {
             val existsPartial = dbQuery {
-                repository.create(City(0L, "New York", fixedInstant, fixedInstant))
+                repository.create(City(0L, "New York", 5.0 ,5.0,fixedInstant, fixedInstant))
                 repository.doesExist("New")
             }
 
@@ -245,7 +245,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should handle special characters in city names`() = runBlocking {
             val exists =  dbQuery {
-                repository.create(City(0L, "São Paulo", fixedInstant, fixedInstant))
+                repository.create(City(0L, "São Paulo", 5.0 ,5.0,fixedInstant, fixedInstant))
                 repository.doesExist("São Paulo")
             }
 
@@ -259,7 +259,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should return true when city id exists`() = runBlocking {
             val city = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             val exists = dbQuery {
@@ -303,7 +303,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should return city when found`() = runBlocking {
             val createdCity = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London",5.0 ,5.0, fixedInstant, fixedInstant))
             }
 
             val foundCity = dbQuery {
@@ -329,13 +329,13 @@ class CityRepositoryImplTest {
         @Test
         fun `should return correct city among multiple cities`() = runBlocking {
             val paris = dbQuery {
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
             val london = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
             val berlin = dbQuery {
-                repository.create(City(0L, "Berlin", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Berlin", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             val foundCity = dbQuery {
@@ -363,7 +363,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should delete city and return 1 when city exists`() = runBlocking {
             val city = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             val deleted = dbQuery {
@@ -391,7 +391,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should not allow deleting same city twice`() = runBlocking {
             val city = dbQuery {
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris",5.0 ,5.0, fixedInstant, fixedInstant))
             }
 
             val firstDelete = dbQuery {
@@ -408,10 +408,10 @@ class CityRepositoryImplTest {
         @Test
         fun `should only delete specified city`() = runBlocking {
             val london = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
             val paris = dbQuery {
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             dbQuery {
@@ -450,9 +450,9 @@ class CityRepositoryImplTest {
         @Test
         fun `should return all cities`() = runBlocking {
             dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
-                repository.create(City(0L, "Berlin", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London",5.0 ,5.0, fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris", 5.0 ,5.0,fixedInstant, fixedInstant))
+                repository.create(City(0L, "Berlin",5.0 ,5.0, fixedInstant, fixedInstant))
             }
 
             val cities = dbQuery {
@@ -468,7 +468,7 @@ class CityRepositoryImplTest {
         @Test
         fun `should return cities with all fields populated`() = runBlocking {
             val createdCity = dbQuery {
-                repository.create(City(0L, "Tokyo", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Tokyo", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             val cities = dbQuery {
@@ -491,7 +491,7 @@ class CityRepositoryImplTest {
         fun `should handle full CRUD lifecycle`() = runBlocking {
             // Create
             val city = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
             assertNotNull(city.cityId)
 
@@ -528,7 +528,7 @@ class CityRepositoryImplTest {
 
             val cities = dbQuery  {
                 cityNames.map { name ->
-                    repository.create(City(0L, name, fixedInstant, fixedInstant))
+                    repository.create(City(0L, name, 5.0 ,5.0,fixedInstant, fixedInstant))
                 }
             }
 
@@ -544,10 +544,10 @@ class CityRepositoryImplTest {
         fun `should maintain data integrity after multiple operations`() = runBlocking {
             // Create multiple cities
             val london = dbQuery {
-                repository.create(City(0L, "London", fixedInstant, fixedInstant))
+                repository.create(City(0L, "London", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
             val paris = dbQuery {
-                repository.create(City(0L, "Paris", fixedInstant, fixedInstant))
+                repository.create(City(0L, "Paris", 5.0 ,5.0,fixedInstant, fixedInstant))
             }
 
             // Update one

--- a/users/src/test/kotlin/com/eros/users/repository/PreferenceRepositoryImplTest.kt
+++ b/users/src/test/kotlin/com/eros/users/repository/PreferenceRepositoryImplTest.kt
@@ -101,7 +101,7 @@ class PreferenceRepositoryImplTest {
     }
 
     suspend fun createCity(cityName: String): City {
-        return cityRepository.create(City(0L, cityName, fixedInstant, fixedInstant))
+        return cityRepository.create(City(0L, cityName, 5.0 ,5.0,fixedInstant, fixedInstant))
     }
 
     fun createUser(): User = runBlocking {

--- a/users/src/test/kotlin/com/eros/users/routes/CityRoutesTest.kt
+++ b/users/src/test/kotlin/com/eros/users/routes/CityRoutesTest.kt
@@ -1,5 +1,459 @@
-package com.eros.users.repository
+package com.eros.users.routes
+
+import com.eros.auth.firebase.FirebaseUserPrincipal
+import com.eros.common.errors.NotFoundException
+import com.eros.common.plugins.configureExceptionHandling
+import com.eros.users.models.City
+import com.eros.users.models.CityDTO
+import com.eros.users.models.CreateCityRequest
+import com.eros.users.models.UpdateCityRequest
+import com.eros.users.service.CityService
+import com.google.firebase.auth.FirebaseToken
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.bearer
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 class CityRoutesTest{
 
+    private val mockCityService = mockk<CityService>()
+
+
+    @Nested
+    inner class `CREATE City`{
+
+        @Test
+        fun `successfully create a city`() = testApplication {
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            val request = CreateCityRequest("London",-5.2, 45.2)
+            val createdCity = createCity(longitude = -5.2, latitude = 45.2)
+
+            coEvery { mockCityService.createCity(request) } returns createdCity
+            coEvery { mockCityService.doesExists(request.cityName) } returns false
+
+            val response = client.post("/city/admin"){
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+
+            val city = response.body<CityDTO>()
+            assertEquals("London",city.cityName)
+
+        }
+
+        @Test
+        fun `successfully create a city EMPLOYEE`() = testApplication {
+            setupTestApp("EMPLOYEE")
+            val client = configuredClient()
+
+            val request = CreateCityRequest("London",-5.2, 45.2)
+            val createdCity = createCity(longitude = -5.2, latitude = 45.2)
+
+            coEvery { mockCityService.createCity(request) } returns createdCity
+            coEvery { mockCityService.doesExists(request.cityName) } returns false
+
+            val response = client.post("/city/admin"){
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+
+            val city = response.body<CityDTO>()
+            assertEquals("London",city.cityName)
+
+        }
+
+        @Test
+        fun `ensure USER role can't create city`() = testApplication {
+            setupTestApp()
+            val client = configuredClient()
+
+            val request = CreateCityRequest("London",-5.2, 45.2)
+
+            val response = client.post("/city/admin"){
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+        @Test
+        fun `Ensure can't create city with empty name`() = testApplication {
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            val request = CreateCityRequest("    ", -5.2, 45.2)
+
+            coEvery { mockCityService.doesExists(request.cityName) } returns false
+            coEvery { mockCityService.createCity(request) } throws IllegalArgumentException("City name must not be empty.")
+
+            val response = client.post("/city/admin") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    }
+
+    @Nested
+    inner class `GET all City`{
+
+        @Test
+        fun `get ALL cities USER`() = testApplication{
+
+            setupTestApp()
+            val client = configuredClient()
+
+            coEvery { mockCityService.getAllCities() } returns listOf(createCity(),createCity(),createCity())
+
+            val response = client.get("/city/all") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(3, response.body<List<CityDTO>>().size)
+        }
+
+        @Test
+        fun `get ALL cities ADMIN`() = testApplication{
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            coEvery { mockCityService.getAllCities() } returns listOf(createCity(),createCity(),createCity())
+
+            val response = client.get("/city/all") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(3, response.body<List<CityDTO>>().size)
+        }
+
+        @Test
+        fun `get ALL cities EMPLOYEE`() = testApplication{
+
+            setupTestApp("EMPLOYEE")
+            val client = configuredClient()
+
+            coEvery { mockCityService.getAllCities() } returns listOf(createCity(),createCity(),createCity())
+
+            val response = client.get("/city/all") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(3, response.body<List<CityDTO>>().size)
+        }
+
+    }
+
+    @Nested
+    inner class `GET single City`{
+
+        @Test
+        fun `successfully retrieve 1 city`() = testApplication{
+            setupTestApp("USER")
+            val client = configuredClient()
+
+            val city = createCity()
+
+            coEvery { mockCityService.findByCityId(0L) } returns city
+
+            val response = client.get("/city/0") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val returnedCity = response.body<CityDTO>()
+            assertEquals(city.cityName, returnedCity.cityName)
+
+        }
+
+        @Test
+        fun `successfully retrieve 1 city ADMIN`() = testApplication{
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            val city = createCity()
+
+            coEvery { mockCityService.findByCityId(0L) } returns city
+
+            val response = client.get("/city/0") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val returnedCity = response.body<CityDTO>()
+            assertEquals(city.cityName, returnedCity.cityName)
+
+        }
+
+        @Test
+        fun `return error if city not found ADMIN`() = testApplication{
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+            
+            coEvery { mockCityService.findByCityId(0L) } throws NotFoundException("city not found.")
+
+            val response = client.get("/city/0") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+            }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+
+        }
+
+    }
+
+
+    @Nested
+    inner class `DELETE City`{
+
+        @Test
+        fun `should delete city ADMIN`() = testApplication{
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            coEvery { mockCityService.deleteCity(0L) } returns 1
+
+            val response = client.delete("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+            }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+
+        }
+
+        @Test
+        fun `should delete city EMPLOYEE`() = testApplication{
+
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            coEvery { mockCityService.deleteCity(0L) } returns 1
+
+            val response = client.delete("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+            }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+
+        }
+
+        @Test
+        fun `USER can't delete city`() = testApplication{
+            setupTestApp()
+            val client = configuredClient()
+
+            val response = client.delete("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+            }
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+        @Test
+        fun `unauthorized can't delete city`() = testApplication{
+            setupTestApp()
+            val client = configuredClient()
+
+            val response = client.delete("/city/admin/0")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+        @Test
+        fun `can't delete city that does not exist`() = testApplication{
+
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+
+            coEvery { mockCityService.deleteCity(0L) } returns 0
+
+            val response = client.delete("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+            }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+    }
+
+    @Nested
+    inner class `PATCH City`{
+
+        @Test
+        fun `successfully patch every field`()= testApplication{
+
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+            val city = createCity()
+            val updatedCity = createCity(0L,"Liverpool",3.4,-4.5)
+            val request = UpdateCityRequest(0L,"Liverpool",3.4,-4.5)
+
+            coEvery { mockCityService.updateCity(0L,request) } returns updatedCity
+
+            val response = client.patch("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val returnedCity = response.body<CityDTO>()
+            assertEquals(updatedCity.cityId,returnedCity.cityId)
+            assertEquals(updatedCity.cityName,returnedCity.cityName)
+            assertEquals(updatedCity.longitude,returnedCity.longitude)
+            assertEquals(updatedCity.latitude,returnedCity.latitude)
+
+        }
+
+        @Test
+        fun `USER CAN'T patch a city`()= testApplication{
+            setupTestApp()
+            val client = configuredClient()
+
+            val response = client.patch("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+            }
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+        @Test
+        fun `successfully patch single field`()= testApplication{
+
+            setupTestApp("ADMIN")
+            val client = configuredClient()
+            val city = createCity()
+            val updatedCity = createCity(0L,"Liverpool",-5.0,45.0)
+            val request = UpdateCityRequest(0L,"Liverpool",)
+
+            coEvery { mockCityService.updateCity(0L,request) } returns updatedCity
+
+            val response = client.patch("/city/admin/0") {
+                setAuthenticatedUser("test-user-id")
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val returnedCity = response.body<CityDTO>()
+            assertEquals(city.cityId,returnedCity.cityId)
+            assertNotEquals(city.cityName,returnedCity.cityName)
+            assertEquals(city.longitude,returnedCity.longitude)
+            assertEquals(city.latitude,returnedCity.latitude)
+
+        }
+    }
+
+
+
+    // Helper functions
+
+    fun createCity(id : Long = 0L, cityName : String = "London", longitude : Double = -5.0, latitude : Double = 45.0) : City {
+        val now = Instant.now()
+        return City(id, cityName, longitude, latitude,now,now)
+    }
+
+    /**
+     * Creates a configured HTTP client for tests with JSON content negotiation.
+     * Each test should create its own client instance to ensure proper serialization.
+     */
+    private fun ApplicationTestBuilder.configuredClient() = createClient {
+        install(ClientContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                prettyPrint = true
+            })
+        }
+    }
+
+    private fun ApplicationTestBuilder.setupTestApp(role : String = "USER") {
+        application {
+            configureExceptionHandling()
+            // Install server-side content negotiation
+            install(ServerContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    prettyPrint = true
+                })
+            }
+
+            // Install authentication
+            install(Authentication) {
+                bearer("firebase-auth") {
+                    realm = "test-realm"
+                    authenticate { credential ->
+                        // Return mock principal based on credential token
+                        // Token format: "user-{userId}"
+                        val userId = credential.token.removePrefix("user-")
+                        val mockToken = mockk<FirebaseToken>(relaxed = true) {
+                            coEvery { uid } returns userId
+                        }
+                        FirebaseUserPrincipal(
+                            uid = userId,
+                            email = "$userId@example.com",
+                            phoneNumber = null,
+                            emailVerified = true,
+                            token = mockToken,
+                            role = role
+                        )
+                    }
+                }
+            }
+
+            routing {
+                authenticate("firebase-auth") {
+                    cityRoutes(mockCityService)
+                }
+            }
+        }
+    }
+
+    private fun HttpRequestBuilder.setAuthenticatedUser(userId: String) {
+        header(HttpHeaders.Authorization, "Bearer user-$userId")
+    }
 }

--- a/users/src/test/kotlin/com/eros/users/routes/QARoutesTest.kt
+++ b/users/src/test/kotlin/com/eros/users/routes/QARoutesTest.kt
@@ -7,7 +7,6 @@ import com.eros.common.errors.NotFoundException
 import com.eros.common.plugins.configureExceptionHandling
 import com.eros.users.ProfileAccessControl
 import com.eros.users.models.AddUserQARequest
-import com.eros.users.models.DeleteUserQARequest
 import com.eros.users.models.Question
 import com.eros.users.models.QuestionDTO
 import com.eros.users.models.UpdateUserQARequest
@@ -335,7 +334,6 @@ class QARoutesTest {
             val client = configuredClient()
 
             val userId = "test-user-123"
-            val request = DeleteUserQARequest(userId = userId, questionId = 999L)
 
             coEvery { mockQAService.deleteUserQA(userId, 999L) } returns 0
 

--- a/users/src/test/kotlin/com/eros/users/routes/UserPreferenceRoutesTest.kt
+++ b/users/src/test/kotlin/com/eros/users/routes/UserPreferenceRoutesTest.kt
@@ -179,7 +179,9 @@ class UserPreferenceRoutesTest {
                     cityId = 1L,
                     cityName = "London",
                     createdAt = Instant.now(),
-                    updatedAt = Instant.now()
+                    updatedAt = Instant.now(),
+                    longitude = 5.0,
+                    latitude = 5.0
                 )
             ),
             reachLevel = ReachLevel.OPEN_MINDED,


### PR DESCRIPTION
Adding lat and long to city table - migration, domain, dto and tests.
With a new CityTest - To check that long+lat is enforced and the name is not empty.

1 change to remove the redundant "DeleteUserQARequest" (forgot to change branches but allow it - its a few lines)