### PR TITLE
feat(#121): MATCHING - view last 24 hours of passes

### DIFF
--- a/matching/src/main/kotlin/com/eros/matching/repository/DailyBatchRepositoryImpl.kt
+++ b/matching/src/main/kotlin/com/eros/matching/repository/DailyBatchRepositoryImpl.kt
@@ -7,10 +7,13 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.insertReturning
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.updateReturning
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 
-class DailyBatchRepositoryImpl : DailyBatchRepository {
+class DailyBatchRepositoryImpl(
+    private val clock: Clock = Clock.systemUTC()
+) : DailyBatchRepository {
 
     override suspend fun findByUserAndDate(userId: String, date: LocalDate): DailyBatch? {
         return UserDailyBatches.selectAll()
@@ -76,7 +79,7 @@ class DailyBatchRepositoryImpl : DailyBatchRepository {
             val incremented = existing.incrementBatchCount()
             update(incremented) ?: throw IllegalStateException("Failed to update batch count for user $userId on $date")
         } else {
-            val now = Instant.now()
+            val now = Instant.now(clock)
             create(
                 DailyBatch(
                     userId = userId,

--- a/matching/src/main/kotlin/com/eros/matching/repository/MatchRepository.kt
+++ b/matching/src/main/kotlin/com/eros/matching/repository/MatchRepository.kt
@@ -64,4 +64,18 @@ interface MatchRepository : IBaseDAO<Long, Match> {
      * @return True if a served match exists (servedAt is not null), false otherwise
      */
     suspend fun hasServedMatch(user1Id: String, user2Id: String): Boolean
+
+    /**
+     * Finds all matches where the user explicitly passed (liked = false) within the last 24 hours.
+     *
+     * Returns matches where:
+     * - user1_id matches the given userId
+     * - liked = false (explicit pass)
+     * - servedAt is not null
+     * - servedAt is within the last 24 hours from now
+     *
+     * @param userId The user whose passes to retrieve
+     * @return List of matches that the user passed on in the last 24 hours
+     */
+    suspend fun findPassesInLast24Hours(userId: String): List<Match>
 }

--- a/matching/src/main/kotlin/com/eros/matching/repository/MatchRepositoryImpl.kt
+++ b/matching/src/main/kotlin/com/eros/matching/repository/MatchRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.eros.database.repository.BaseDAOImpl
 import com.eros.matching.models.Match
 import com.eros.matching.tables.Matches
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greaterEq
@@ -12,11 +13,14 @@ import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 
-class MatchRepositoryImpl : BaseDAOImpl<Long, Match>(Matches, Matches.matchId), MatchRepository {
+class MatchRepositoryImpl(
+    private val clock: Clock = Clock.systemUTC()
+) : BaseDAOImpl<Long, Match>(Matches, Matches.matchId), MatchRepository {
 
     // -------------------------------------------------------------------------
     // BaseDAOImpl required implementations
@@ -112,5 +116,19 @@ class MatchRepositoryImpl : BaseDAOImpl<Long, Match>(Matches, Matches.matchId), 
                 (Matches.user2Id eq user2Id) and
                 (Matches.servedAt.isNotNull())
             }.empty()
+    }
+
+    override suspend fun findPassesInLast24Hours(userId: String): List<Match> {
+        val twentyFourHoursAgo = Instant.now(clock).minusSeconds(24 * 60 * 60)
+
+        return Matches.selectAll()
+            .where {
+                (Matches.user1Id eq userId) and
+                (Matches.liked eq false) and
+                (Matches.servedAt.isNotNull()) and
+                (Matches.servedAt greaterEq twentyFourHoursAgo)
+            }
+            .orderBy(Matches.servedAt to SortOrder.DESC)
+            .map { it.toDomain() }
     }
 }

--- a/matching/src/main/kotlin/com/eros/matching/routes/MatchRoutes.kt
+++ b/matching/src/main/kotlin/com/eros/matching/routes/MatchRoutes.kt
@@ -78,22 +78,25 @@ fun Route.matchRoutes(matchService: MatchService) {
             }
         }
 
-        get("/latest/{uid}") {
-            // get the most recent 24 hours action of user from match table, where decision is not null and equal to false on liked
-            // this will allow a user to get a view of the last 24 hours, so can like if they accidentally said no
-            // due to events they cant unsend a like once sent will have to cancel date in date section
-        }
-
-        get("/today/{uid}") {
-            // fetch the daily batch's for today
-            // a user has 21 potential matchs available a day
-            // we will send this in 3 lots of 7
-            // they should not be able to get the next batch until all actionable events taken upon the users presented
-            // returned value should be a list of userIds with matchId.
-            // The system should then call get on the public profile info
-            // Or should we return a list of basic info with userId, such as Lightweight Public Profile that will allow a user
-            // to see the name, thumbnail and badges until they click and get full profile?
-            // probably more optimal for later, but does this cross concerns modules or does it simply quicken up process
+        /**
+         * GET /match/last-24 - Fetch profiles user passed on in last 24 hours
+         *
+         * Returns all profiles the authenticated user said "no" to within the last 24 hours,
+         * allowing them to reconsider and potentially change their decision to "like".
+         * This is a "second chance" feature for accidental swipes.
+         *
+         * The 24-hour window is calculated from the servedAt timestamp (when the match was shown).
+         * Users can change pass→like within this window by calling PATCH /match/action/{matchId}.
+         *
+         * Responses:
+         * - 200 OK: List<UserMatchProfile> - List of passed profiles with matchIds
+         * - 200 OK: [] - Empty list if no passes in last 24 hours
+         * - 401 Unauthorized: Not authenticated
+         */
+        get("/last-24") {
+            val principal = call.requireFirebasePrincipal()
+            val passes = matchService.getPassesInLast24Hours(principal.uid)
+            call.respond(HttpStatusCode.OK, passes)
         }
 
         /**

--- a/matching/src/main/kotlin/com/eros/matching/routes/MatchRoutes.kt
+++ b/matching/src/main/kotlin/com/eros/matching/routes/MatchRoutes.kt
@@ -32,7 +32,7 @@ fun Route.matchRoutes(matchService: MatchService) {
         }
 
         get("/{matchId}"){
-            val id = call.parameters["matchId"]?.toLong()
+            call.parameters["matchId"]?.toLong()
                 ?: throw BadRequestException("Invalid matchId provided.")
         }
 
@@ -71,7 +71,7 @@ fun Route.matchRoutes(matchService: MatchService) {
             try {
                 val matches = matchService.fetchDailyBatch(principal.uid)
                 call.respond(HttpStatusCode.OK, matches)
-            } catch (e: NoMatchesAvailableException) {
+            } catch (_: NoMatchesAvailableException) {
                 call.respond(HttpStatusCode.NoContent)
             } catch (e: DailyBatchLimitExceededException) {
                 call.respond(HttpStatusCode.TooManyRequests, mapOf("error" to e.message))

--- a/matching/src/main/kotlin/com/eros/matching/service/MatchService.kt
+++ b/matching/src/main/kotlin/com/eros/matching/service/MatchService.kt
@@ -10,6 +10,7 @@ import com.eros.matching.repository.DailyBatchRepository
 import com.eros.matching.repository.MatchRepository
 import com.eros.matching.transaction.TransactionManager
 import com.eros.users.service.UserService
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -23,7 +24,8 @@ class MatchService(
     private val matchRepository: MatchRepository,
     private val dailyBatchRepository: DailyBatchRepository,
     private val userService: UserService,
-    private val transactionManager: TransactionManager
+    private val transactionManager: TransactionManager,
+    private val clock: Clock = Clock.systemUTC()
 ) {
 
     companion object {
@@ -36,7 +38,9 @@ class MatchService(
      *
      * Business rules:
      * - Match must exist (throws NotFoundException if not found)
-     * - User cannot change action once taken (throws ConflictException if liked is not null)
+     * - User cannot change like→pass (prevents unmatching)
+     * - User can change pass→like only within 24 hours of servedAt
+     * - After 24 hours, pass decisions become permanent
      * - Updates match with liked value and current timestamp
      *
      * @param matchId The ID of the match to update
@@ -44,7 +48,7 @@ class MatchService(
      * @param like Whether the user liked (true) or passed (false)
      * @return Updated match record
      * @throws NotFoundException if match doesn't exist
-     * @throws ConflictException if user already took action on this match
+     * @throws ConflictException if user already took action or trying to change outside 24-hour window
      * @throws ForbiddenException if user doesn't own the match
      */
     suspend fun matchAction(matchId: Long, userId: String, like: Boolean): Match = transactionManager.execute {
@@ -57,13 +61,31 @@ class MatchService(
         }
 
         // Check if user has already taken action
-        // hasUserActed() returns true when servedAt is set and updatedAt > servedAt
-        if (existingMatch.hasUserActed() && existingMatch.isLiked()) {
-            throw ConflictException("You have already taken action on this match")
+        if (existingMatch.hasUserActed()) {
+            // Prevent like→pass (cannot unmatch)
+            if (existingMatch.isLiked() && !like) {
+                throw ConflictException("Cannot change from like to pass. You have already liked this profile.")
+            }
+
+            // Prevent pass→like after 24 hours (pass becomes permanent)
+            if (!existingMatch.isLiked() && like) {
+                val servedAt = existingMatch.servedAt
+                    ?: throw ConflictException("Cannot change action on unserved match")
+
+                val twentyFourHoursAgo = Instant.now(clock).minusSeconds(24 * 60 * 60)
+                if (servedAt.isBefore(twentyFourHoursAgo)) {
+                    throw ConflictException("Cannot change pass to like. The 24-hour reconsideration window has expired.")
+                }
+            }
+
+            // Prevent changing action if already set to the same value
+            if (existingMatch.isLiked() == like) {
+                throw ConflictException("You have already ${if (like) "liked" else "passed on"} this profile.")
+            }
         }
 
         // Update match with action
-        val updatedMatch = existingMatch.recordAction(like)
+        val updatedMatch = existingMatch.recordAction(like, Instant.now(clock))
         matchRepository.update(matchId, updatedMatch)
             ?: throw NotFoundException("Match with ID $matchId was deleted or not found during update")
     }
@@ -110,7 +132,7 @@ class MatchService(
                 matchId = match.matchId,
                 user1Id = match.user1Id,
                 user2Id = match.user2Id,
-                matchedAt = Instant.now(),
+                matchedAt = Instant.now(clock),
             )
         }
 
@@ -151,7 +173,7 @@ class MatchService(
         }
 
         // Mark matches as served
-        val servedAt = Instant.now()
+        val servedAt = Instant.now(clock)
         val matchIds = unservedMatches.map { it.matchId }
         matchRepository.markAsServed(matchIds, servedAt)
 
@@ -217,6 +239,31 @@ class MatchService(
         val servedDate = LocalDate.ofInstant(servedAt, ZoneId.of("UTC"))
 
         servedDate.isAfter(today.minusDays(1))  && servedDate.isBefore(today.plusDays(1))
+    }
+
+    /**
+     * Fetches all profiles that the user passed on in the last 24 hours.
+     *
+     * This allows users to reconsider and potentially like profiles they accidentally passed.
+     * The 24-hour window is calculated from the servedAt timestamp.
+     *
+     * Business rules:
+     * - Only matches where user explicitly passed (liked = false)
+     * - Only matches served within the last 24 hours
+     * - Returns UserMatchProfile including matchId to enable re-action
+     * - Returns empty list if no passes in last 24 hours
+     *
+     * @param userId The user whose passes to retrieve
+     * @return List of UserMatchProfile for profiles the user passed on
+     */
+    suspend fun getPassesInLast24Hours(userId: String): List<UserMatchProfile> = transactionManager.execute {
+        val passedMatches = matchRepository.findPassesInLast24Hours(userId)
+
+        // Build lightweight profile responses
+        passedMatches.mapNotNull { match ->
+            val servedAt = match.servedAt ?: return@mapNotNull null
+            buildUserMatchProfile(match, servedAt)
+        }
     }
 }
 

--- a/matching/src/test/kotlin/com/eros/matching/service/MatchServiceTest.kt
+++ b/matching/src/test/kotlin/com/eros/matching/service/MatchServiceTest.kt
@@ -205,22 +205,25 @@ class MatchServiceTest {
                 matchService.matchAction(1L, "user1", false)
             }
 
-            // Assert on the exception behavior
-            assertTrue(exception.message!!.contains("already taken action"))
+            // Assert on the exception behavior - like→pass is prevented
+            assertTrue(exception.message!!.contains("Cannot change from like to pass"))
         }
 
         @Test
         fun `should allow changing pass to like within 24 hours`() = runTest {
+            // Use a recent timestamp (within last 24 hours)
+            val recentServedAt = Instant.now().minusSeconds(3600) // 1 hour ago
+
             val match = createTestMatch(
                 matchId = 1L,
                 user1Id = "user1",
                 user2Id = "user2",
                 liked = false,
-                createdAt = fixedInstant,
-                updatedAt = fixedInstant.plusSeconds(120), // Previously passed
-                servedAt = fixedInstant
+                createdAt = recentServedAt.minusSeconds(60),
+                updatedAt = recentServedAt.plusSeconds(120), // Previously passed
+                servedAt = recentServedAt
             )
-            val updatedMatch = match.recordAction(true, fixedInstant.plusSeconds(180))
+            val updatedMatch = match.recordAction(true, Instant.now())
 
             coEvery { matchRepository.findById(1L) } returns match
             coEvery { matchRepository.update(1L, any()) } returns updatedMatch
@@ -448,8 +451,8 @@ class MatchServiceTest {
                 matchService.matchUser(1L, "user1", true)
             }
 
-            // Assert on the exception behavior
-            assertTrue(exception.message!!.contains("already taken action"))
+            // Assert on the exception behavior - can't like again when already liked
+            assertTrue(exception.message!!.contains("already liked"))
         }
     }
 


### PR DESCRIPTION
  1. Repository Layer (MatchRepository.kt & MatchRepositoryImpl.kt)

  - Added findPassesInLast24Hours() method that queries matches where:
    - User explicitly passed (liked = false)
    - Match was served (servedAt IS NOT NULL)
    - Served within last 24 hours from now
    - Results ordered by servedAt DESC (most recent first)

  2. Service Layer (MatchService.kt)

  - Added getPassesInLast24Hours() method that returns List<UserMatchProfile>
  - Enhanced matchAction() method with time-based constraints:
    -  Prevents like→pass (cannot unmatch)
    -  Allows pass→like only within 24 hours of servedAt
    - After 24 hours, pass decisions become permanent
    - Clear error messages for each constraint violation

  3. Route Layer (MatchRoutes.kt)

  - Implemented GET /match/last-24 endpoint
  - Returns authenticated user's passes from last 24 hours
  - Returns empty list if no recent passes
  - Includes matchId in response to enable re-action via PATCH /match/action/{matchId}

  4. Test Updates (MatchServiceTest.kt)

  - Fixed 3 failing tests to align with new validation logic:
    - Updated error message assertions for like→pass prevention
    - Fixed timestamp issues for 24-hour window testing
    - Updated duplicate action error messages
    
   Resolves: #121 